### PR TITLE
Ensure get_full_path resolves correctly

### DIFF
--- a/opendoors/utils.py
+++ b/opendoors/utils.py
@@ -6,13 +6,10 @@ import html
 import os
 import re
 import shutil
-from os.path import join
+import sys
 from pathlib import Path
 
 import unicodedata
-
-ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
-
 
 def get_full_path(path):
     """
@@ -20,7 +17,8 @@ def get_full_path(path):
     :param path: A relative path fragment. If this is already the absolute path, just return it.
     :return: The absolute path.
     """
-    return join(path) if Path(path).is_absolute() else join(ROOT_DIR, path)
+    full_path: Path = Path(path).resolve(strict=False)
+    return str(full_path)
 
 
 def copy_to_dir(old_file_path, new_file_dir, new_file_name):


### PR DESCRIPTION
Prior to this patch, path fragments passed into the get_full_path
function were not actually resolved fully. Instead, they were blindly
concatenated with the path to __file__ if the string was not fully
qualified. However, not all un-fully-qualified paths are relative to the
current directory: for example, "~/foo" would be treated incorrectly by
the pre-patch code.