### PR TITLE
metadata: handle NULLs from SQL better

### DIFF
--- a/efiction/chapters.py
+++ b/efiction/chapters.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List
 
 from opendoors.mysql import SqlDb
-from opendoors.utils import get_full_path, normalize, print_progress, make_banner
+from opendoors.utils import get_full_path, normalize, print_progress, make_banner, key_find
 
 
 class EFictionChapters:
@@ -73,7 +73,7 @@ class EFictionChapters:
                             raw = f.read()
 
                 text = normalize(raw)
-                if old_chapter['endnotes']:
+                if key_find('endnotes', old_chapter):
                     text = text + f"\n\n\n<hr>\n{old_chapter['endnotes']}"
 
                 query = """

--- a/efiction/metadata.py
+++ b/efiction/metadata.py
@@ -103,10 +103,10 @@ class EFictionMetadata:
 
     def _convert_story_tags(self, old_story):
         old_tags = {
-            'rating': old_story['rid'].split(','),
-            'categories': old_story['catid'].split(','),
-            'classes': old_story['classes'].split(','),
-            'characters': old_story['charid'].split(',')
+            'rating': key_find('rid', old_story, '').split(','),
+            'categories': key_find('catid', old_story, '').split(','),
+            'classes': key_find('classes', old_story, '').split(','),
+            'characters': key_find('charid', old_story, '').split(',')
         }
         ratings = [r['id'] for r in self.ratings if str(r['original_tagid']) in old_tags['rating']]
         categories = [c['id'] for c in self.categories if str(c['original_tagid']) in old_tags['categories']]

--- a/efiction/metadata.py
+++ b/efiction/metadata.py
@@ -8,7 +8,7 @@ from unidecode import unidecode
 from efiction.tag_converter import TagConverter
 from opendoors.mysql import SqlDb
 from opendoors.sql_utils import parse_remove_comments, write_statements_to_file, add_create_database
-from opendoors.utils import print_progress, get_full_path, normalize
+from opendoors.utils import print_progress, get_full_path, normalize, key_find
 
 
 class EFictionMetadata:
@@ -144,9 +144,9 @@ class EFictionMetadata:
         for old_story in old_stories:
             new_story = {
                 'id': old_story['sid'],
-                'title': (old_story['title'] or '').strip(),
+                'title': key_find('title', old_story, '').strip(),
                 'summary': normalize(old_story['summary']),
-                'notes': (old_story['storynotes'] or '').strip(),
+                'notes': key_find('storynotes', old_story, '').strip(),
                 'date': str(old_story['date']),
                 'updated': str(old_story['updated']),
                 'language_code': language_code
@@ -167,7 +167,7 @@ class EFictionMetadata:
             self.logger.debug(f"  authors...")
             self._convert_author_join(new_story, old_story['uid'])
             coauthors = []
-            if old_story['coauthors'] is not None and old_story['coauthors'] != "":
+            if key_find('coauthors', old_story):
                 for authorid in old_story['coauthors'].split(","):
                     coauthors.append(authorid.strip())
             for coauthor in coauthors:

--- a/opendoors/utils.py
+++ b/opendoors/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sys
+from typing import Mapping
 from pathlib import Path
 
 import unicodedata
@@ -43,6 +44,24 @@ def check_if_file_exists(config, section, option):
     """
     return config.has_option(section, option) and Path(config[section][option]).exists
 
+def key_find(needle: object, haystack: Mapping[object, object], none_val: object = None) -> object:
+    """
+    Helper function to search a Dict (or any Mappable type) for a key, returning
+    the value if it exists. This avoids KeyErrors when it is not certain if the key
+    exists in the array or not.
+    :param needle: The key to return, if it exists
+    :param haystack: The Dict/Mappable to search
+    :return The value if the key is in the haystack, or none_val if not
+    """
+
+    if needle in haystack:
+        value = haystack[needle]
+
+    # On occasion, we may get literal None's returned for a value instead of the
+    # key being missing.  Make sure to treat those as failures.
+    if value is not None:
+        return value
+    return none_val
 
 def make_banner(border_char: chr, banner_text: str, padding=2):
     """

--- a/opendoors/utils.py
+++ b/opendoors/utils.py
@@ -54,13 +54,10 @@ def key_find(needle: object, haystack: Mapping[object, object], none_val: object
     :return The value if the key is in the haystack, or none_val if not
     """
 
-    if needle in haystack:
-        value = haystack[needle]
-
     # On occasion, we may get literal None's returned for a value instead of the
     # key being missing.  Make sure to treat those as failures.
-    if value is not None:
-        return value
+    if needle in haystack and haystack[needle] is not None:
+        return haystack[needle]
     return none_val
 
 def make_banner(border_char: chr, banner_text: str, padding=2):


### PR DESCRIPTION
This commit introduces a utils function key_find which can be used to
prevent KeyErrors when searching mappable types for potentially missing
keys.