### PR TITLE
Invalid timestamp format

### DIFF
--- a/opendoors/big_insert.py
+++ b/opendoors/big_insert.py
@@ -16,7 +16,7 @@ class BigInsert:
         self._sql.ensure_local_infile()
         self._database = database
         self._columns = columns
-        self._tempfile = NamedTemporaryFile("w+", delete=False, suffix=".otw.tmp")
+        self._tempfile = NamedTemporaryFile("w+", delete=False, suffix=".otw.tmp", encoding="utf-8")
         # convert windows slashes to unix becouse windows needs it like that?
         windows_friendly_name = self._tempfile.name.replace("\\", "/")
         # We are storing data as a `tab separated` file

--- a/opendoors/sql_utils.py
+++ b/opendoors/sql_utils.py
@@ -76,12 +76,15 @@ def parse_remove_comments(original_db_sql: str):
 
 def remove_invalid_date_default(statement: str) -> str:
     """
-    Replace datetime column definitions which are invalid in MySQL 5.7.
+    Replace datetime and/or timestamp column definitions which are invalid in MySQL 5.7.
     :param statement: SQL statement to modify
     :return: modified statement
     """
-    return re.sub(r"datetime not null default '0000-00-00 00:00:00'", "datetime DEFAULT NULL", statement,
+    stmt = re.sub(r"datetime not null default '0000-00-00 00:00:00'", "datetime DEFAULT NULL", statement,
                   flags=re.IGNORECASE)
+    stmt = re.sub(r"timestamp[\(][0-9]+[\)]", "timestamp", statement,
+                  flags=re.IGNORECASE)
+    return stmt
 
 
 def remove_unwanted_statements(statement: str) -> str:


### PR DESCRIPTION
I only changed `opendoors/sql_utils.py` so I'm not sure why github thinks I changed `opendoors/big_insert.py`??

This fixes the `invalid default values for event_time` error discovered when trying to process Chad's HP archive.