### PR TITLE
OD-698 Additional tag tables

### DIFF
--- a/efiction/metadata.py
+++ b/efiction/metadata.py
@@ -28,11 +28,8 @@ class EFictionMetadata:
         self.working_open_doors = self.config['Processing']['open_doors_working_db']
         self.tag_converter = TagConverter(config, logger, sql)
         self.authors = []
-        self.ratings = []
-        self.ratings_nonstandard: bool = False
-        self.categories = []
-        self.classes = []
-        self.characters = []
+        self.tag_tables = {}
+        self.tag_tables_is_standard = {}
 
     def create_open_doors_db(self, step_path):
         """
@@ -101,7 +98,7 @@ class EFictionMetadata:
             self.sql
         )
         for old_character in old_characters:
-            parent = [ct['original_tag'] for ct in self.categories if ct['original_tagid'] == old_character['catid']]
+            parent = [ct['original_tag'] for ct in self.tag_tables['categories'] if ct['original_tagid'] == old_character['catid']]
             new_tag = {
                 'id': old_character['charid'],
                 'name': old_character['charname'],
@@ -113,27 +110,34 @@ class EFictionMetadata:
         return self.sql.execute_and_fetchall(self.working_open_doors,
                                              "SELECT * FROM tags WHERE `original_type` = 'character'")
 
+    def _convert_story_tag_table(self, table_name, old_tags):
+        # Standard for tag table to be organized by id.
+        original_tagid = 'original_tagid'
+        if self.tag_table_is_standard[table_name]:
+            # Tag table identified by name rather than id.
+            original_tagid = 'original_tag'
+        return [c['id'] for c in self.tag_tables[table_name] if str(c[original_tagid]) in old_tags[table_name]]
+
     def _convert_story_tags(self, old_story):
         old_tags = {
             'rating': key_find('rid', old_story, '').split(','),
             'categories': key_find('catid', old_story, '').split(','),
+            'warnings': key_find('wid', old_story, '').split(','),
             'classes': key_find('classes', old_story, '').split(','),
+            'genres': key_find('gid', old_story, '').split(','),
             'characters': key_find('charid', old_story, '').split(',')
         }
 
-        if self.ratings_nonstandard:
-            ratings = [r['id'] for r in self.ratings if str(r['original_tag']) in old_tags['rating']]
-        else:
-            ratings = [r['id'] for r in self.ratings if str(r['original_tagid']) in old_tags['rating']]
-        categories = [c['id'] for c in self.categories if str(c['original_tagid']) in old_tags['categories']]
-        classes = [c['id'] for c in self.classes if str(c['original_tagid']) in old_tags['classes']]
-        characters = [c['id'] for c in self.classes if str(c['original_tagid']) in old_tags['characters']]
+        new_tags = {}
+
+        for tag_table_name in self.tag_tables.keys():
+            new_tags[tag_table_name] = self._convert_story_tag_table(tag_table_name, old_tags)
 
         return {
-            'rating': ratings,
-            'categories': categories,
-            'classes': classes,
-            'characters': characters
+            'rating': new_tags['rating'],
+            'categories': new_tags['categories'] + new_tags['warnings'],
+            'classes': new_tags['classes'] + new_tags['genres'],
+            'characters': new_tags['characters']
         }
 
     def _convert_tags_join(self, new_story, tags, sql=None):
@@ -161,7 +165,11 @@ class EFictionMetadata:
         # access the coauthors table using the story ID
         full_query = f"""SELECT * FROM coauthors WHERE sid = {new_story['id']};"""
         # get a dict of coauthor IDs for the story
-        authors = sql.execute_and_fetchall(self.working_original, full_query)
+        try:
+            authors = sql.execute_and_fetchall(self.working_original, full_query)
+        except Exception as e:
+            authors = None
+            self.logger.info("No coauthors table...")
         # We only try to operate on this result if it is not None
         if authors:
             for author in authors:
@@ -226,13 +234,16 @@ class EFictionMetadata:
         """
         Extract all tags by category.
         """
-        self.ratings = self.tag_converter.convert_ratings()
-        self.ratings_nonstandard = self.tag_converter.check_for_nonstandard_ratings()
-        self.categories = self.tag_converter.convert_categories()
-        self.classes = self.tag_converter.convert_classes()
+        self.tag_tables['rating'] = self.tag_converter.convert_ratings()
+        self.tag_tables['categories'] = self.tag_converter.convert_categories()
+        self.tag_tables['warnings'] = self.tag_converter.convert_warnings()
+        self.tag_tables['classes'] = self.tag_converter.convert_classes()
+        self.tag_tables['genres'] = self.tag_converter.convert_genres()
 
         old_characters = self.sql.read_table_to_dict(self.working_original, "characters")
-        self.characters = self._convert_characters(old_characters)
+        self.tag_tables['characters'] = self._convert_characters(old_characters)
+
+        self.tag_table_is_standard = self.tag_converter.check_for_nonstandard_tag_tables()
 
     def convert_original_to_open_doors(self, step_path: str):
         """

--- a/efiction/simplified.py
+++ b/efiction/simplified.py
@@ -16,7 +16,7 @@ class EFictionSimplified:
     # EFiction names its tables as xxxxx_tablename and we only need to keep a few to process the archive
     tables_to_keep = (
         "authors", "categories", "challenges", "chapters", "characters", "classes", "classtypes", "coauthors",
-        "inseries", "ratings", "series", "stories")
+        "inseries", "ratings", "series", "stories", "warnings", "genres")
 
     def __init__(self, config: ConfigParser, logger: Logger, sql: SqlDb):
         self.sql = sql

--- a/efiction/tag_converter.py
+++ b/efiction/tag_converter.py
@@ -47,10 +47,11 @@ class TagConverter:
                     id_name = 'charid'
 
                 try:
-                    query = f"SELECT {id_name} FROM stories WHERE {id_name} NOT IN (SELECT {id_name} FROM {tag_table_name});"
+                    query = f"SELECT {id_name} FROM stories;"
                     tags = self.sql.execute_and_fetchall(self.working_original, query)
                     try:
-                        int(''.join(map(lambda story_tags: story_tags[id_name].replace(',', ''), tags)))
+                        tags = list(map(lambda story_tags: story_tags[id_name].replace(',', ''), tags))
+                        int(''.join(tags))
                         tag_tables[tag_table_name] = False
                     except Exception as e:
                         # Non-integer in identifier

--- a/efiction/tag_converter.py
+++ b/efiction/tag_converter.py
@@ -15,19 +15,43 @@ class TagConverter:
         self.working_original = self.config['Processing']['simplified_original_db']
         self.working_open_doors = self.config['Processing']['open_doors_working_db']
 
-    def check_for_nonstandard_ratings(self) -> bool:
+    def check_for_nonstandard_tag_tables(self) -> bool:
         """
-        Determine whether or not the eFiction ratings table correctly uses rating
-        IDs, or if it is 'non-standard' from using rating names as identifiers
+        Determine whether or not the given eFiction tag table correctly uses IDs,
+        or if it is 'non-standard' from using tag names as identifiers
         :return: True if non-standard, otherwise False
         """
 
-        count: List[Dict[str, int]] = self.sql.execute_and_fetchall(self.working_original,
-                                                                    "SELECT count(*) as cnt FROM stories WHERE rid NOT IN"
-                                                                    "(SELECT rid FROM ratings)")
+        tag_tables = {}
 
-        return bool(count and count[0]['cnt'] > 0)
+        for tag_table_name in ['rating', 'categories', 'warnings', 'classes', 'genres', 'characters']:
+            original_name = tag_table_name
 
+            if tag_table_name == 'rating':
+                tag_table_name = 'ratings'
+                id_name = 'rid'
+            elif tag_table_name == 'categories':
+                id_name = 'catid'
+            elif tag_table_name == 'warnings':
+                id_name = 'wid'
+            elif tag_table_name == 'classes':
+                id_name = 'classes'
+            elif tag_table_name == 'genres':
+                id_name = 'gid'
+            elif tag_table_name == 'characters':
+                id_name = 'charid'
+
+            query = f"SELECT count(*) as cnt FROM stories WHERE {id_name} NOT IN (SELECT {id_name} FROM {tag_table_name});"
+
+            try:
+                count: List[Dict[str, int]] = self.sql.execute_and_fetchall(self.working_original, query)
+                tag_tables[original_name] = bool(count and count[0]['cnt'] > 0)
+            except Exception as e:
+                self.logger.info(e)
+                self.logger.info("No such table?")
+                tag_tables[original_name] = 0
+
+        return tag_tables
 
 
     def convert_ratings(self):
@@ -75,6 +99,29 @@ class TagConverter:
         return self.sql.execute_and_fetchall(self.working_open_doors,
                                              "SELECT * FROM tags WHERE `original_type` = 'category'")
 
+    def convert_warnings(self):
+        """
+        Convert the eFiction categories table to Open Doors tags.
+        :return: Open Doors tags with the original type "categories"
+        """
+        old_categories, current, total = self.sql.read_table_with_total(self.working_original, "warnings")
+        for old_category in old_categories:
+            new_tag = {
+                'id': old_category['wid'],
+                'parent': "",
+                'name': old_category['warning'],
+                'description': old_category['warning']
+            }
+            query = f"""
+            INSERT INTO tags 
+                (`original_tagid`, `original_tag`, `original_type`, `original_description`, `original_parent`)
+            VALUES {new_tag['id'], new_tag['name'], 'category', new_tag['description'], new_tag['parent']};
+            """
+            self.sql.execute(self.working_open_doors, query)
+            current = print_progress(current, total, "categories converted")
+        return self.sql.execute_and_fetchall(self.working_open_doors,
+                                             "SELECT * FROM tags WHERE `original_type` = 'category'")
+
     def convert_classes(self):
         """
         Convert the eFiction classes table to Open Doors tags.
@@ -88,6 +135,28 @@ class TagConverter:
                 'id': old_class['class_id'],
                 'name': old_class['class_name'],
                 'parent': ", ".join(parent) if parent != [] else ""
+            }
+            query = f"""
+            INSERT INTO tags 
+                (`original_tagid`, `original_tag`, `original_type`, `original_parent`)
+            VALUES {new_tag['id'], new_tag['name'], 'class', new_tag['parent']};
+            """
+            self.sql.execute(self.working_open_doors, query)
+            current = print_progress(current, total, "classes converted")
+        return self.sql.execute_and_fetchall(self.working_open_doors,
+                                             "SELECT * FROM tags WHERE `original_type` = 'class'")
+
+    def convert_genres(self):
+        """
+        Convert the eFiction classes table to Open Doors tags.
+        :return: Open Doors tags with the original type "class"
+        """
+        old_classes, current, total = self.sql.read_table_with_total(self.working_original, "genres")
+        for old_class in old_classes:
+            new_tag = {
+                'id': old_class['gid'],
+                'name': old_class['genre'],
+                'parent': ""
             }
             query = f"""
             INSERT INTO tags 

--- a/opendoors/mysql.py
+++ b/opendoors/mysql.py
@@ -70,8 +70,12 @@ class SqlDb:
         :return: The contents of the table as a dict.
         """
         cursor = self.conn.cursor()
-        cursor.execute(f"SELECT * FROM {database}.{tablename};")
-        return cursor.fetchall()
+        try:
+            cursor.execute(f"SELECT * FROM {database}.{tablename};")
+            return cursor.fetchall()
+        except Exception as e:
+            self.logger.info(f"No table {tablename} in {database}...")
+            return []
 
     def read_table_with_total(self, database: str, table_name: str):
         """


### PR DESCRIPTION
In addition to "categories", also tries "warnings", and addition to "classes", also tries "genres". (Currently it is possible for the process to finish with 0 categories or classes; not sure if this is the desired behavior, can change if desired.)

Due to the amount of repeated code for each kind of table for different kinds of tags (ratings, categories, warnings, classes, genres, and characters), the attributes for each of these tables have been merged into a single "tag_tables" attribute. This also should make it easier to add future tables as tags.