### PR TITLE
OD-1727: Allow for spaces in tag lists after commas

### DIFF
--- a/efiction/metadata.py
+++ b/efiction/metadata.py
@@ -129,12 +129,12 @@ class EFictionMetadata:
 
     def _convert_story_tags(self, old_story):
         old_tags = {
-            'rating': key_find('rid', old_story, '').split(','),
-            'categories': key_find('catid', old_story, '').split(','),
-            'warnings': key_find('wid', old_story, '').split(','),
-            'classes': key_find('classes', old_story, '').split(','),
-            'genres': key_find('gid', old_story, '').split(','),
-            'characters': key_find('charid', old_story, '').split(',')
+            'rating': [t.strip() for t in key_find('rid', old_story, '').split(',')],
+            'categories': [t.strip() for t in key_find('catid', old_story, '').split(',')],
+            'warnings': [t.strip() for t in key_find('wid', old_story, '').split(',')],
+            'classes': [t.strip() for t in key_find('classes', old_story, '').split(',')],
+            'genres': [t.strip() for t in key_find('gid', old_story, '').split(',')],
+            'characters': [t.strip() for t in key_find('charid', old_story, '').split(',')],
         }
 
         new_tags = {}


### PR DESCRIPTION
What Makes The Desert Beautiful had tags that were separated in a human readable way (i.e., `a, b, c` instead of `a,b,c`).

Add support for this to the eFiction processor.